### PR TITLE
Remove obsolete Annotation tab

### DIFF
--- a/app.py
+++ b/app.py
@@ -66,8 +66,6 @@ demo = gr.Blocks(theme=Base())
 
 with demo:
     gr.Markdown("# SLEDA Tools")
-    with gr.Tab("Annotation"):
-        gr.HTML(annotation_html)
 
     with gr.Tab("Preprocessing"):
         input_excel = gr.File(label="Excel or CSV file")


### PR DESCRIPTION
## Summary
- drop the unused Annotation tab from `app.py`

## Testing
- `python -m py_compile app.py`
- `venv/bin/python app.py` *(fails to fully run in this environment due to no browser, but server starts)*