### PR TITLE
Normalize column names

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ This simplified workflow should help you get started even if you are new to Pyth
 
 You can launch the included `app.py` script on Hugging Face Spaces or locally. It provides a small Gradio interface with three tabs:
 
-1. **Preprocessing** – upload an Excel **or** CSV file and download the converted CSV.
-2. **Training** – upload a CSV (with a `label` column) to train a simple model. The accuracy and a downloadable model file are returned.
+1. **Preprocessing** – upload an Excel **or** CSV file and download the converted CSV. All column names are normalised to lowercase.
+2. **Training** – upload a CSV (containing a column `label`) to train a simple model. The accuracy and a downloadable model file are returned.
 3. **Evaluation** – upload a trained model file together with a CSV to measure accuracy on that data.
 
 To run the app locally, install the dependencies and execute:
@@ -72,7 +72,7 @@ If you are new to Python, follow these steps to run each tool in order:
    ```bash
    pip install -r requirements.txt
    ```
-3. **Preprocess the data** – Convert the Excel files by executing:
+3. **Preprocess the data** – Convert the Excel files by executing (column names will be normalised to lowercase):
    ```bash
    python preprocessing.py --input-dir "SLDEA Data" --output-dir csv_output
    ```

--- a/app.py
+++ b/app.py
@@ -7,6 +7,12 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import accuracy_score
 from sklearn.model_selection import train_test_split
 
+
+def canonicalize_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Strip whitespace and lower-case column names for consistent access."""
+    df.rename(columns=lambda c: c.strip().lower(), inplace=True)
+    return df
+
 def preprocess_excel(file):
     """Convert an uploaded Excel or CSV file to CSV and return the path."""
     if file is None:
@@ -21,6 +27,7 @@ def preprocess_excel(file):
     except Exception as e:
         raise gr.Error(f"Failed to read file: {e}")
 
+    canonicalize_columns(df)
     tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".csv")
     df.to_csv(tmp.name, index=False)
     return tmp.name
@@ -36,6 +43,8 @@ def train_model(csv_file):
         df = pd.read_excel(csv_file.name, engine="openpyxl")
     else:
         df = pd.read_csv(csv_file.name, encoding="utf-8-sig")
+
+    canonicalize_columns(df)
 
     if "label" not in df.columns:
         raise gr.Error("CSV must contain a column named 'label'")
@@ -63,6 +72,8 @@ def evaluate_model(model_file, csv_file):
         df = pd.read_excel(csv_file.name, engine="openpyxl")
     else:
         df = pd.read_csv(csv_file.name, encoding="utf-8-sig")
+
+    canonicalize_columns(df)
 
     if "label" not in df.columns:
         raise gr.Error("CSV must contain a column named 'label'")


### PR DESCRIPTION
## Summary
- canonicalize column names by stripping spaces and lowering case
- apply normalization in preprocessing, training, and evaluation
- document the behavior in README

## Testing
- `python -m py_compile app.py`
